### PR TITLE
Handle DNS Unhandled Promise Rejections

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- '8'
+- '10'
 before_script:
 - npm run test
 - node make.js build

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # url-target-validator.js
 Used to ensure that the targets of payloads go to the right place.
+
+## Release notes
+### 2.0.0
+Solves problems when running on Node.js 10.x by using dns.promises API. This version also requires Node 10.x. to run.
+
+### 1.0.0
+Initial version targeting Node.js 8.10.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "url-target-validator",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Utilities supporting authorization, request logging and other often reused parts of microservices.",
   "main": "src/urlValidator.js",
   "files": [
@@ -43,6 +43,6 @@
     "sinon": "^7.4.1"
   },
   "engines": {
-    "node": ">=8.10.0"
+    "node": ">=10"
   }
 }

--- a/src/urlValidator.js
+++ b/src/urlValidator.js
@@ -5,6 +5,14 @@ const ipRegex = require('ip-regex');
 // https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml
 const list = ['10.', '127.', '169.254.', '192.0.0.', '192.0.', '192.31.', '255.255.255.', '::1'];
 
+const handleRejection = (funcToExecute, reject) => {
+  try {
+    return funcToExecute();
+  } catch (err) {
+    reject(err);
+  }
+}
+
 module.exports = class {
   /**
    * Validates an URL to be conform to a URL format, and optionally validates the protocol to be HTTPS.
@@ -37,8 +45,8 @@ module.exports = class {
       let ipv4Error = false;
       let ipv6Error = false;
       ipAddresses = [];
-      const ipv4Resolver = new Promise((resolve, reject) => dns.resolve4(hostname, (error, addresses) => error ? reject(error) : resolve(addresses)));
-      const ipv6Resolver = new Promise((resolve, reject) => dns.resolve6(hostname, (error, addresses) => error ? reject(error) : resolve(addresses)));
+      const ipv4Resolver = new Promise((resolve, reject) => handleRejection(() => dns.resolve4(hostname, (error, addresses) => error ? reject(error) : resolve(addresses)), reject));
+      const ipv6Resolver = new Promise((resolve, reject) => handleRejection(() => dns.resolve6(hostname, (error, addresses) => error ? reject(error) : resolve(addresses)), reject));
       try {
         const result = await ipv4Resolver;
         ipAddresses = ipAddresses.concat(result);

--- a/src/urlValidator.js
+++ b/src/urlValidator.js
@@ -1,22 +1,9 @@
 const { URL } = require('url');
-const dns = require('dns');
+const dns = require('dns').promises;
 const ipRegex = require('ip-regex');
 
 // https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml
 const list = ['10.', '127.', '169.254.', '192.0.0.', '192.0.', '192.31.', '255.255.255.', '::1'];
-
-const promisify = funcToPromisify => {
-  return (...args) => {
-    // eslint-disable-next-line no-async-promise-executor
-    return new Promise(async (resolve, reject) => {
-      try {
-        await funcToPromisify(...args, (error, success) => error ? reject(error) : resolve(success));
-      } catch (exception) {
-        reject(exception);
-      }
-    });
-  };
-};
 
 module.exports = class {
   /**
@@ -51,17 +38,15 @@ module.exports = class {
       let ipv6Error = false;
       ipAddresses = [];
 
-      const ipv4Resolver = promisify(dns.resolve4);
-      const ipv6Resolver = promisify(dns.resolve6);
       try {
-        const result = await ipv4Resolver(hostname);
+        const result = await dns.resolve4(hostname);
         ipAddresses = ipAddresses.concat(result);
       } catch (error) {
         ipv4Error = true;
       }
 
       try {
-        const result = await ipv6Resolver(hostname);
+        const result = await dns.resolve6(hostname);
         ipAddresses = ipAddresses.concat(result);
       } catch (error) {
         ipv6Error = true;

--- a/tests/urlValidator.test.js
+++ b/tests/urlValidator.test.js
@@ -109,4 +109,20 @@ describe('urlValidator.js', () => {
       });
     });
   });
+
+  describe('handles async errors inside of the dns library', () => {
+    it('handles dns.resolve4 and dns.resolve6 promise rejection', async () => {
+      const dnsMock = sandbox.mock(dns);
+      dnsMock.expects('resolve4').rejects('error');
+      dnsMock.expects('resolve6').rejects('error');
+
+      let error;
+      try {
+        await new UrlValidator().validate('https://unit-test.cimpress.io');
+      } catch (capturedError) {
+        error = capturedError;
+      }
+      expect(error && error.message).to.eql('DnsResolutionError');
+    });
+  });
 });


### PR DESCRIPTION
On Node 10.16.3 the `dns.resolve6` does not always call the callback with error, but instead throws directly.
```
"errorType":"Runtime.UnhandledPromiseRejection",
"errorMessage":"queryAaaa ENODATA",
"reason":
{
    "stack":"Error: queryAaaa ENODATA
        at QueryReqWrap.onresolve [as oncomplete] (dns.js:196:19)",
    "message":"queryAaaa ENODATA",
    "errno":"ENODATA",
    "code":"ENODATA",
    "syscall":"queryAaaa"
}
```

Doing a safety catch here, to gracefully handle the rejections.
The alternative is fixing the node `dns` library or moving to a newer node version. Open for a discussion :)